### PR TITLE
remove headers that should be set by the ELB

### DIFF
--- a/nginx/nginx.conf.in
+++ b/nginx/nginx.conf.in
@@ -35,9 +35,9 @@ http {
     }
     location / {
       proxy_pass                          http://localhost:8135;
-      proxy_set_header Host               $host;
-      proxy_set_header X-Real-IP          $remote_addr;
-      proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+#      proxy_set_header Host               $host;
+#      proxy_set_header X-Real-IP          $remote_addr;
+#      proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
 #      proxy_set_header X-Forwarded-Proto  $scheme;
     }
   }

--- a/nginx/nginx.conf.in
+++ b/nginx/nginx.conf.in
@@ -35,7 +35,7 @@ http {
     }
     location / {
       proxy_pass                          http://localhost:8135;
-#      proxy_set_header Host               $host;
+      proxy_set_header Host               $host;
 #      proxy_set_header X-Real-IP          $remote_addr;
 #      proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
 #      proxy_set_header X-Forwarded-Proto  $scheme;


### PR DESCRIPTION
AWS ELB should set all the `X-Forwarded-XXX` headers.

`Host` should also aready be defined. 